### PR TITLE
Solves ambiguous call to isinf and isnan in LocoMouse_class.cpp

### DIFF
--- a/LocoMouse_Core/LocoMouse_class.cpp~
+++ b/LocoMouse_Core/LocoMouse_class.cpp~
@@ -2043,6 +2043,7 @@ MATSPARSE LocoMouse::pairwisePotential(std::vector<Candidate> &Ci, std::vector<C
 
 				D.put(j, i, inv_dist * alpha_vel);
 
+				if (std::isinf(inv_dist * alpha_vel)) {
 					cout << "Inf detected" << endl;
 				}
 				if (std::isnan(inv_dist * alpha_vel)) {


### PR DESCRIPTION
It resolves the ambiguous call to isinf and isnan in LocoMouse_class.cpp. 